### PR TITLE
build.sh启动服务的时候，把服务启动到后台

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -107,7 +107,7 @@ if [ "$1" = "start" ] ; then
   ln $JAR_FILE $SERVICE_JAR
   chmod a+x $SERVICE_JAR
 
-  $SERVICE_JAR start --configservice --adminservice
+  nohup $SERVICE_JAR start --configservice --adminservice &
 
   rc=$?
   if [[ $rc != 0 ]];
@@ -151,7 +151,7 @@ if [ "$1" = "start" ] ; then
   ln $JAR_FILE $PORTAL_JAR
   chmod a+x $PORTAL_JAR
 
-  $PORTAL_JAR start --portal
+  nohup $PORTAL_JAR start --portal &
 
   rc=$?
   if [[ $rc != 0 ]];


### PR DESCRIPTION
之前的版本build.sh启动的时候，执行到启动configservice将不再往下执行