### PR TITLE
demo.sh 添加环境变量 JAVA_OPTS、数据库账号密码  的支持

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -1,22 +1,35 @@
 #!/bin/bash
 
+# handle env
 if [[ -n "$JAVA_OPTS" ]]; then
   echo JAVA_OPTS = $JAVA_OPTS
 fi
 
+if [[ -n "$APOLLO_CONFIG_DB_USERNAME" ]]; then
+  echo APOLLO_CONFIG_DB_USERNAME = "$APOLLO_CONFIG_DB_USERNAME"
+fi
+
 if [[ -n "$APOLLO_CONFIG_DB_PASSWORD" ]]; then
-  echo APOLLO_CONFIG_DB_PASSWORD = $APOLLO_CONFIG_DB_PASSWORD
+  echo APOLLO_CONFIG_DB_PASSWORD = "${APOLLO_CONFIG_DB_PASSWORD//?/*}"
+fi
+
+if [[ -n "$APOLLO_PORTAL_DB_USERNAME" ]]; then
+  echo APOLLO_PORTAL_DB_USERNAME = "$APOLLO_PORTAL_DB_USERNAME"
+fi
+
+if [[ -n "$APOLLO_PORTAL_DB_PASSWORD" ]]; then
+  echo APOLLO_PORTAL_DB_PASSWORD = "${APOLLO_PORTAL_DB_PASSWORD//?/*}"
 fi
 
 # apollo config db info
 apollo_config_db_url="jdbc:mysql://localhost:3306/ApolloConfigDB?characterEncoding=utf8&serverTimezone=Asia/Shanghai"
-apollo_config_db_username=root
-apollo_config_db_password=$APOLLO_CONFIG_DB_PASSWORD
+apollo_config_db_username=${APOLLO_CONFIG_DB_USERNAME:-root}
+apollo_config_db_password=${APOLLO_CONFIG_DB_PASSWORD:-}
 
 # apollo portal db info
 apollo_portal_db_url="jdbc:mysql://localhost:3306/ApolloPortalDB?characterEncoding=utf8&serverTimezone=Asia/Shanghai"
-apollo_portal_db_username=root
-apollo_portal_db_password=$APOLLO_CONFIG_DB_PASSWORD
+apollo_portal_db_username=${APOLLO_PORTAL_DB_USERNAME:-root}
+apollo_portal_db_password=${APOLLO_PORTAL_DB_PASSWORD:-}
 
 # =============== Please do not modify the following content =============== #
 

--- a/demo.sh
+++ b/demo.sh
@@ -1,14 +1,22 @@
 #!/bin/bash
 
+if [[ -n "$JAVA_OPTS" ]]; then
+  echo JAVA_OPTS = $JAVA_OPTS
+fi
+
+if [[ -n "$APOLLO_CONFIG_DB_PASSWORD" ]]; then
+  echo APOLLO_CONFIG_DB_PASSWORD = $APOLLO_CONFIG_DB_PASSWORD
+fi
+
 # apollo config db info
 apollo_config_db_url="jdbc:mysql://localhost:3306/ApolloConfigDB?characterEncoding=utf8&serverTimezone=Asia/Shanghai"
 apollo_config_db_username=root
-apollo_config_db_password=
+apollo_config_db_password=$APOLLO_CONFIG_DB_PASSWORD
 
 # apollo portal db info
 apollo_portal_db_url="jdbc:mysql://localhost:3306/ApolloPortalDB?characterEncoding=utf8&serverTimezone=Asia/Shanghai"
 apollo_portal_db_username=root
-apollo_portal_db_password=
+apollo_portal_db_password=$APOLLO_CONFIG_DB_PASSWORD
 
 # =============== Please do not modify the following content =============== #
 
@@ -29,7 +37,6 @@ eureka_service_url=$config_server_url/eureka/
 portal_url=http://localhost:8070
 
 # JAVA OPTS
-echo $JAVA_OPTS
 BASE_JAVA_OPTS="$JAVA_OPTS -Denv=dev"
 CLIENT_JAVA_OPTS="$BASE_JAVA_OPTS -Dapollo.meta=$config_server_url"
 SERVER_JAVA_OPTS="$BASE_JAVA_OPTS -Dspring.profiles.active=github -Deureka.service.url=$eureka_service_url"

--- a/demo.sh
+++ b/demo.sh
@@ -29,7 +29,8 @@ eureka_service_url=$config_server_url/eureka/
 portal_url=http://localhost:8070
 
 # JAVA OPTS
-BASE_JAVA_OPTS="-Denv=dev"
+echo $JAVA_OPTS
+BASE_JAVA_OPTS="$JAVA_OPTS -Denv=dev"
 CLIENT_JAVA_OPTS="$BASE_JAVA_OPTS -Dapollo.meta=$config_server_url"
 SERVER_JAVA_OPTS="$BASE_JAVA_OPTS -Dspring.profiles.active=github -Deureka.service.url=$eureka_service_url"
 PORTAL_JAVA_OPTS="$BASE_JAVA_OPTS -Ddev_meta=$config_server_url -Dspring.profiles.active=github,auth -Deureka.client.enabled=false -Dhibernate.query.plan_cache_max_size=192"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - apollo-db
     environment:
       JAVA_OPTS: '-Xms100m -Xmx1000m -Xmn100m -Xss256k -XX:MetaspaceSize=10m -XX:MaxMetaspaceSize=250m'
+      # APOLLO_CONFIG_DB_PASSWORD: 'apollo'
 
   apollo-db:
     image: mysql:5.7
@@ -21,6 +22,7 @@ services:
     environment:
       TZ: Asia/Shanghai
       MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+      # MYSQL_ROOT_PASSWORD: 'apollo'
     depends_on:
       - apollo-dbdata
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,12 @@ services:
       - "8090:8090"
     links:
       - apollo-db
-    environment:
-      JAVA_OPTS: '-Xms100m -Xmx1000m -Xmn100m -Xss256k -XX:MetaspaceSize=10m -XX:MaxMetaspaceSize=250m'
-      # APOLLO_CONFIG_DB_PASSWORD: 'apollo'
+    #environment:
+      #JAVA_OPTS: '-Xms100m -Xmx1000m -Xmn100m -Xss256k -XX:MetaspaceSize=10m -XX:MaxMetaspaceSize=250m'
+      #APOLLO_CONFIG_DB_USERNAME: 'root'
+      #APOLLO_CONFIG_DB_PASSWORD: 'apollo'
+      #APOLLO_PORTAL_DB_USERNAME: 'root'
+      #APOLLO_PORTAL_DB_PASSWORD: 'apollo'
 
   apollo-db:
     image: mysql:5.7
@@ -22,7 +25,7 @@ services:
     environment:
       TZ: Asia/Shanghai
       MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-      # MYSQL_ROOT_PASSWORD: 'apollo'
+      #MYSQL_ROOT_PASSWORD: 'apollo'
     depends_on:
       - apollo-dbdata
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - "8090:8090"
     links:
       - apollo-db
+    environment:
+      JAVA_OPTS: '-Xms100m -Xmx1000m -Xmn100m -Xss256k -XX:MetaspaceSize=10m -XX:MaxMetaspaceSize=250m'
 
   apollo-db:
     image: mysql:5.7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     ports:
       - "8080:8080"
       - "8070:8070"
+      - "8090:8090"
     links:
       - apollo-db
 


### PR DESCRIPTION
&emsp; 宋老师好，最近我在开发一个spring cloud的示例项目，由于本地内存比较紧张，所以拓展了一下环境变量 ***JAVA_OPTS***  与 ***APOLLO_CONFIG_DB_PASSWORD*** 的功能。与现有apollo教程是兼容的。

&emsp; 希望能够合并，与社区同进步。

&emsp; 具体变更如下：

* demo.sh 在BASE_JAVA_OPT中加入环境变量JAVA_OPTS，如果设置了就在控制台中输出便于debug。
* demo.sh 新增了 APOLLO_CONFIG_DB_PASSWORD 设置密码的支持，如果设置了就在控制台中输出便于debug。
* docker-compose.yml添加暴露端口8090，添加environment中添加常规减少内存消耗JAVA_OPTS配置。实际稳定运行820Mb左右。如图：

![6a6d928ec1d079e48dfcd235783ec32](https://user-images.githubusercontent.com/89335097/135707536-1b6dcbde-f9bd-4769-802a-d1cca61c701e.png)

@nobodyiam 
