### PR TITLE
let .sql .conf file end with *nix line style

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.sh text eol=lf
+*.sql text eol=lf
+*.conf text eol=lf


### PR DESCRIPTION
sql与conf文件也会造成win环境下构建失败，修改git默认检出方式为LF