### PR TITLE
fix: disable H2 console in quick start

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -73,7 +73,8 @@ BASE_JAVA_OPTS="$JAVA_OPTS"
 CLIENT_JAVA_OPTS="$BASE_JAVA_OPTS -Dapollo.meta=$config_server_url"
 APOLLO_CONFIG_DB_CONFIG="-Dspring.config-datasource.url=$apollo_config_db_url -Dspring.config-datasource.username=$apollo_config_db_username -Dspring.config-datasource.password=$apollo_config_db_password"
 APOLLO_PORTAL_DB_CONFIG="-Dspring.portal-datasource.url=$apollo_portal_db_url -Dspring.portal-datasource.username=$apollo_portal_db_username -Dspring.portal-datasource.password=$apollo_portal_db_password"
-SERVER_JAVA_OPTS="$BASE_JAVA_OPTS -Dspring.profiles.active=github,database-discovery,auth -Dlogging.file.name=$SERVICE_LOG -Dspring.profiles.group.github=$spring_profiles_group_github $APOLLO_CONFIG_DB_CONFIG $APOLLO_PORTAL_DB_CONFIG"
+H2_CONSOLE_CONFIG="-Dspring.h2.console.enabled=false"
+SERVER_JAVA_OPTS="$BASE_JAVA_OPTS -Dspring.profiles.active=github,database-discovery,auth -Dlogging.file.name=$SERVICE_LOG -Dspring.profiles.group.github=$spring_profiles_group_github $APOLLO_CONFIG_DB_CONFIG $APOLLO_PORTAL_DB_CONFIG $H2_CONSOLE_CONFIG"
 
 function checkJava {
   if [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then


### PR DESCRIPTION
## Summary

- Disable the H2 Console in the default `demo.sh` server JVM options.
- Keep the Docker / `demo.sh start` Quick Start path aligned with its default MySQL startup mode, where H2 Console is unnecessary.

## Tests

- `bash -n demo.sh`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to disable the Spring H2 console when starting the service.
  - Included the setting in the service’s Java startup options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->